### PR TITLE
chore: bump to `stable-slim` base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9.5-slim
+FROM debian:stable-slim
 
 RUN apt update
 RUN apt -yq install rsync openssh-client


### PR DESCRIPTION
My build this morning failed because `9.5-slim` doesn't have access openssh-client and rsync in the apt repository any more.  I think we can build with some certainty on `stable-slim` because it should have reliable access to those packages...  I think.  😁 If not we could lock it to a specific, newer version like `sid-slim`.

For reference, the failure in my action was:
```
Step 1/13 : FROM debian:9.5-slim
  9.5-slim: Pulling from library/debian
  f17d81b4b[6](https://github.com/funwhilelost/repo/actions/runs/4840303407/jobs/8625865611#step:2:6)92: Pulling fs layer
  f1[7](https://github.com/funwhilelost/repo/actions/runs/4840303407/jobs/8625865611#step:2:7)d[8](https://github.com/funwhilelost/repo/actions/runs/4840303407/jobs/8625865611#step:2:8)1b4b6[9](https://github.com/funwhilelost/repo/actions/runs/4840303407/jobs/8625865611#step:2:9)2: Verifying Checksum
  f17d81b4b692: Download complete
  f17d81b4b692: Pull complete
  Digest: sha256:ef6be890318a[10](https://github.com/funwhilelost/repo/actions/runs/4840303407/jobs/8625865611#step:2:10)5f7401d0504c01c2888daa5d9e45b308cf0e45c7cb8e44634f
  Status: Downloaded newer image for debian:9.5-slim
   ---> 4b4471f624dc
  Step 2/[13](https://github.com/funwhilelost/repo/actions/runs/4840303407/jobs/8625865611#step:2:13) : RUN apt update
   ---> Running in a9418086ff1b
  
  WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
  
  Ign:1 http://deb.debian.org/debian stretch InRelease
  Ign:2 http://deb.debian.org/debian stretch-updates InRelease
  Err:3 http://deb.debian.org/debian stretch Release
    404  Not Found
  Err:4 http://deb.debian.org/debian stretch-updates Release
    404  Not Found
  Ign:5 http://security.debian.org/debian-security stretch/updates InRelease
  Err:6 http://security.debian.org/debian-security stretch/updates Release
    404  Not Found [IP: [15](https://github.com/funwhilelost/repo/actions/runs/4840303407/jobs/8625865611#step:2:15)1.101.[19](https://github.com/funwhilelost/repo/actions/runs/4840303407/jobs/8625865611#step:2:19)4.132 80]
  Reading package lists...
  E: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
  E: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
  E: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
  The command '/bin/sh -c apt update' returned a non-zero code: 100
```